### PR TITLE
SmartSPIM spec init

### DIFF
--- a/schemas/imaging/Instrument Schema.json
+++ b/schemas/imaging/Instrument Schema.json
@@ -9,11 +9,11 @@
 		},	
 		"Microscope Type": {
 	    	"type": "string",
-	    	"enum": ["mesoSPIM", "exaSPIM", "diSPIM", "confocal", "two photon","other"]
+	    	"enum": ["mesoSPIM", "exaSPIM", "diSPIM", "smartSPIM", "confocal", "two photon","other"]
 	  	},
 	  	"Microscope Manufacturer": {
 	    	"type": "string",
-			"enum": ["Olympus", "Leica", "custom"]
+			"enum": ["Olympus", "Leica", "LifeCanvas", "custom"]
 	  	},
 	  	"Microscope Model": {
 	    	"type": "number"
@@ -73,7 +73,7 @@
 			"properties": {
 				"Manufacturer": {
 					"type": "string",
-					"enum": ["Olympus", "Nikon", "Special Optics"] 
+					"enum": ["Olympus", "Nikon", "Special Optics", "ThorLabs"] 
 				},
 				"Model": {
 					"type": "number"
@@ -83,15 +83,15 @@
 				},
 				"Numerical aperture": {
 					"type": "number",
-					"enum": [0.4, 0.7]
+					"enum": [0.2, 0.4, 0.7]
 				},
 				"Magnification": {
 					"type": "string",
-					"enum": ["10X", "20X"]
+					"enum": ["3.6X", "10X", "20X"]
 				},
 				"Immersion": {
 					"type": "string",
-					"enum": ["air","water", "oil"]
+					"enum": ["air","water", "oil", "multi"]
 				}
 			},
 			"required": [


### PR DESCRIPTION
Adding values to `enum` fields of instrument schema for LifeCanvas SmartSPIM.

Other notes:
- `stage` object properties appear to be copied from the `camera` object and need updated.
- Some of these instruments have either magnifications that varies depending on the exact immersion media or are different than the manufactured part.
    - One example of the former is the SpecialOptics objectives that the diSPIM instruments use.
    - One example of the later is the ThorLabs objective used on the SmartSPIM (spec is 4X but after altering for the instrument goes to 3.6X). 
    -  I'm not sure how best to account for this, but there could be another field to record either the actual magnification or a scale factor.