### PR TITLE
fix: Fixes typo in version field

### DIFF
--- a/schemas/processing.json
+++ b/schemas/processing.json
@@ -8,7 +8,7 @@
             "description": "The URL reference to the schema.",
             "title": "Described by"
         },
-        "schema_version": {
+        "version": {
             "type": "string",
             "const": "0.0.1",
             "description": "Schema version",


### PR DESCRIPTION
Closes #68

"version" is listed in the requirements, but the field is called "schema_version." the field should be renamed to be consistent with the other schemas.